### PR TITLE
Test patch for win64 builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/awkward1-{{ version }}.tar.gz
   sha256: f25db4920677029a92e92b994f1056902724b6a947549254c1446bdc6e388671
+  patches:
+    - patch-windows-build.patch
 
 build:
-  number: 0
+  number: 1
   skip: true   # [py<=34]
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/patch-windows-build.patch
+++ b/recipe/patch-windows-build.patch
@@ -1,0 +1,26 @@
+From 63e51a29965a14d9ecbd09425999f803a9a00e64 Mon Sep 17 00:00:00 2001
+From: Lindsey Gray <lindsey.gray@gmail.com>
+Date: Fri, 18 Sep 2020 16:14:15 -0500
+Subject: [PATCH] patch to windows builds in conda pipelines
+
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 2617e8f..b34f5d2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -67,7 +67,8 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
+                 "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(cfg.upper(), extdir),
+                 "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
+             ]
+-            if sys.maxsize > 2**32 and os.environ.get("CMAKE_GENERATOR") != "NMake Makefiles":
++            excluded_gens = ["NMake Makefiles", "Visual Studio 15 2017 Win64"]
++            if sys.maxsize > 2**32 and os.environ.get("CMAKE_GENERATOR") not in excluded_gens:
+                 cmake_args += ["-A", "x64"]
+         else:
+             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+-- 
+2.28.0
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a test patch to see if an additional veto in for cmake is needed.